### PR TITLE
jrsonnet-fmt: --use-tabs now defaults to disabled

### DIFF
--- a/cmds/jrsonnet-fmt/src/main.rs
+++ b/cmds/jrsonnet-fmt/src/main.rs
@@ -28,7 +28,7 @@ struct Opts {
 	#[arg(long, default_value = "4")]
 	indent: u8,
 	/// Force hard tab for indentation
-	#[arg(long, default_value = "true")]
+	#[arg(long)]
 	use_tabs: bool,
 	/// Max formatted source width
 	#[arg(long, default_value = "100")]

--- a/crates/jrsonnet-formatter/src/lib.rs
+++ b/crates/jrsonnet-formatter/src/lib.rs
@@ -910,7 +910,7 @@ impl FormatOptions {
 	pub fn new() -> Self {
 		Self {
 			indent: 4,
-			use_tabs: true,
+			use_tabs: false,
 			max_width: 100,
 		}
 	}


### PR DESCRIPTION
## Problem Summary

In `cmds/jrsonnet-fmt/src/main.rs`, the `--use-tabs` flag was declared as:

```rust
/// Force hard tab for indentation
#[arg(long, default_value = "true")]
use_tabs: bool,
```

The help text ("Force hard tab") implies an opt-in boolean flag that is off by default, but the `default_value = "true"` made it **always** `true`:

- not passing the flag ==> `true`
- passing the flag ==> `true`
- `--use-tabs=false` ==> clap error ("unexpected value")

So the formatter always emitted Tab indentation, and the `--indent <N>` option had no visible effect.

## Fix

Remove the `default_value` so the flag is a plain opt-in
